### PR TITLE
Fix psreadline color

### DIFF
--- a/home/powershell/profile.d/psreadline.ps1
+++ b/home/powershell/profile.d/psreadline.ps1
@@ -9,6 +9,11 @@ if (Get-Module 'PSReadLine') {
         Set-PSReadLineKeyHandler -Key Tab -Function Complete
     }
     Set-PSReadLineOption -HistorySearchCursorMovesToEnd
+    # See: https://github.com/microsoft/terminal/issues/15452
+    Set-PSReadLineOption -Colors @{
+        ContinuationPrompt = "`e[39m"
+        Default = "`e[39m"
+        Type = "`e[39m"
+    }
 }
-
 


### PR DESCRIPTION
Windows Terminal with light theme and default PSReadLine colors causes some text to not be visible.